### PR TITLE
Matrix: Turn off fg/bg text mode

### DIFF
--- a/desk.acc/matrix.s
+++ b/desk.acc/matrix.s
@@ -24,9 +24,11 @@
         jsr     SaveText
         sta     TXTSET
         sta     CLR80VID
+        sta     DHIRESOFF
 
         jsr     Run
 
+        sta     DHIRESON
         sta     TXTCLR
         sta     SET80VID
         jsr     RestoreText


### PR DESCRIPTION
Fixes AppleColor 100 display issue where text mode is entered without clearing double hires mode, which is foreground/background text mode for that card.