### PR TITLE
shave some bytes

### DIFF
--- a/disk_copy/main.s
+++ b/disk_copy/main.s
@@ -625,11 +625,9 @@ not_last:
 mask:   and     #$01
 
         ;; Set Y to 0 (if clear) or $FF (if set)
-        bne     set
-        tay                     ; Y=A=0
-        beq     :+              ; always
-set:    ldy     #$FF
-:
+        eor     #$FF
+        tay
+        iny
 
         ;; Now compute block number
         ;; Why do this? Isn't this stashed anywhere else???


### PR DESCRIPTION
Original code takes 7 bytes to turn A=0/1 into Y=0/$FF

This has the same effect but does it in 4 bytes. It clobbers A, but the next instruction clobbers A anyway