### PR TITLE
Pre-clear AUX text screen

### DIFF
--- a/desktop.system/desktop.system.s
+++ b/desktop.system/desktop.system.s
@@ -930,6 +930,18 @@ str_slash_desktop:
         DEFINE_QUIT_PARAMS quit_params
 
 have128k:
+        ;; Clear AUX text screen memory so junk doesn't show
+        sta     RAMWRTON
+        lda     #$A0
+        ldx     #0
+:       sta     $400,x
+        sta     $500,x
+        sta     $600,x
+        sta     $700,x
+        inx
+        bne     :-
+        sta     RAMWRTOFF
+
         ;; Turn on 80-column mode
         jsr     SLOT3ENTRY
         jsr     HOME


### PR DESCRIPTION
Calling $C300 results in a momentary glitch when it hits $C00D to turn on 80-column text mode. Any latent junk in AUX $400 screen memory show while the firmware clear happens. Now we clear the memory before it is ever visible.