### PR TITLE
Preserve 'screen holes' for //c & //c+

### DIFF
--- a/desktop.system/desktop.system.s
+++ b/desktop.system/desktop.system.s
@@ -931,15 +931,20 @@ str_slash_desktop:
 
 have128k:
         ;; Clear AUX text screen memory so junk doesn't show
+        ;; while protecting 'screen holes' for //c
         jsr     HOME
         sta     RAMWRTON
         lda     #$A0
-        ldx     #0
-:       sta     $400,x
-        sta     $500,x
-        sta     $600,x
-        sta     $700,x
-        inx
+        ldx     #$78
+:       sta     $400-1,x
+        sta     $480-1,x
+        sta     $500-1,x
+        sta     $580-1,x
+        sta     $600-1,x
+        sta     $680-1,x
+        sta     $700-1,x
+        sta     $780-1,x
+        dex
         bne     :-
         sta     RAMWRTOFF
 


### PR DESCRIPTION
Used by serial printer and modem ports to store config info. Set by ROM on bootup.


from Apple IIc Technical Reference 2nd ed - p. 128

"All the screen holes in auxiliary memory, and many of them in main memory, are reserved for special use by Apple IIc-family firmware--for example, to store initialization information. Do not use any locations marked reserved in this manual."