### PR TITLE
Show cursor in Analog Clock & Digital Clock

### DIFF
--- a/desk.acc/analog.clock.s
+++ b/desk.acc/analog.clock.s
@@ -63,7 +63,7 @@ parsed: .tag    ParsedDateTime
 ;;; DA Init
 
 .proc Init
-        MGTK_CALL MGTK::HideCursor
+        MGTK_CALL MGTK::ObscureCursor
 
         ;; Clear screen to black
         MGTK_CALL MGTK::InitPort, grafport
@@ -97,7 +97,6 @@ exit:
         MGTK_CALL MGTK::DrawMenuBar
         JSR_TO_MAIN JUMP_TABLE_HILITE_MENU
 
-        MGTK_CALL MGTK::ShowCursor
         rts                     ; exits input loop
 .endproc ; InputLoop
 

--- a/desk.acc/digital.clock.s
+++ b/desk.acc/digital.clock.s
@@ -70,7 +70,7 @@ parsed: .tag    ParsedDateTime
 ;;; DA Init
 
 .proc Init
-        MGTK_CALL MGTK::HideCursor
+        MGTK_CALL MGTK::ObscureCursor
 
         ;; Clear screen to black
         MGTK_CALL MGTK::InitPort, grafport
@@ -103,7 +103,6 @@ exit:
         MGTK_CALL MGTK::DrawMenuBar
         JSR_TO_MAIN JUMP_TABLE_HILITE_MENU
 
-        MGTK_CALL MGTK::ShowCursor
         rts                     ; exits input loop
 .endproc ; InputLoop
 


### PR DESCRIPTION
Reverts a change which permanently hid the cursor in Analog Clock & Digital Clock DAs.