### PR TITLE
Invert the inside of buttons, not the whole of them

### DIFF
--- a/toolkits/btk.s
+++ b/toolkits/btk.s
@@ -150,7 +150,17 @@ ret:
 
 .proc _Invert
         MGTK_CALL MGTK::SetPenMode, penXOR
+        inc16   rect+MGTK::Rect::x1
+        inc16   rect+MGTK::Rect::y1
+        dec16   rect+MGTK::Rect::x2
+        dec16   rect+MGTK::Rect::y2
+
         MGTK_CALL MGTK::PaintRect, rect
+        dec16   rect+MGTK::Rect::x1
+        dec16   rect+MGTK::Rect::y1
+        inc16   rect+MGTK::Rect::x2
+        inc16   rect+MGTK::Rect::y2
+
         rts
 .endproc ; _Invert
 


### PR DESCRIPTION
I've always been a little irritated at the way click tracking works in buttons. This patch only invert the inside of the buttons when clicking, not the whole rectangle, this prevents the little 'corners' to show when clicking a button.

I know I know, not terribly exciting but... :-)