### PR TITLE
SSC Bug Fixes

### DIFF
--- a/desk.acc/print.catalog.s
+++ b/desk.acc/print.catalog.s
@@ -868,8 +868,11 @@ fail:
 
         ldx     SLOT1,Y
         stx     vector+1
+        stx     MSLOT
         ldx     #>SLOT1                  ; X = $Cn
         ldy     #((>SLOT1)<<4)&%11110000 ; Y = $n0
+        ;; A2MISC TechNote #3 SSC C800 space
+        sta     $CFFF
 vector: jsr     SLOT1                    ; self-modified
 
         ;; Back to what DeskTop expects

--- a/desk.acc/print.catalog.s
+++ b/desk.acc/print.catalog.s
@@ -868,11 +868,11 @@ fail:
 
         ldx     SLOT1,Y
         stx     vector+1
-        stx     MSLOT
         ldx     #>SLOT1                  ; X = $Cn
         ldy     #((>SLOT1)<<4)&%11110000 ; Y = $n0
         ;; A2MISC TechNote #3 SSC C800 space
-        sta     $CFFF
+        stx     MSLOT
+        stx     $CFFF
 vector: jsr     SLOT1                    ; self-modified
 
         ;; Back to what DeskTop expects

--- a/desk.acc/print.screen.s
+++ b/desk.acc/print.screen.s
@@ -240,8 +240,11 @@ loop:   jsr     SendRow
 .proc GoCard
         ldx     SLOT1,y
         stx     vector+1
+        stx     MSLOT
         ldx     #>SLOT1                  ; X = $Cn
         ldy     #((>SLOT1)<<4)&%11110000 ; Y = $n0
+        ;; A2MISC TechNote #3 SSC C800 space
+        sta     $CFFF
 vector: jmp     SLOT1                    ; self-modified
 .endproc ; GoCard
 

--- a/desk.acc/print.screen.s
+++ b/desk.acc/print.screen.s
@@ -240,11 +240,11 @@ loop:   jsr     SendRow
 .proc GoCard
         ldx     SLOT1,y
         stx     vector+1
-        stx     MSLOT
         ldx     #>SLOT1                  ; X = $Cn
         ldy     #((>SLOT1)<<4)&%11110000 ; Y = $n0
         ;; A2MISC TechNote #3 SSC C800 space
-        sta     $CFFF
+        stx     MSLOT
+        stx     $CFFF
 vector: jmp     SLOT1                    ; self-modified
 .endproc ; GoCard
 

--- a/inc/apple2.inc
+++ b/inc/apple2.inc
@@ -133,6 +133,7 @@ CON_QUARTER     := $F070        ; 1/4
 
 ;;; Other
 FBUFFR          := $100
+MSLOT           := $7F8         ; Slot in use, in case of IRQ
 
 
 ;;; ============================================================


### PR DESCRIPTION
Following Apple II Misc Tech Note #3 on SSC bugs: https://mirrors.apple2.org.za/Apple%20II%20Documentation%20Project/Computers/Apple%20II/Apple%20II/Documentation/Misc%20%23003%20SSC%20Firmware%20Bug.pdf

Add a store of $CFFF to allow switching $C800 space, and store of MSLOT in case an interrupt occurs, to the pascal interface calls in GoCard in both desk accessories that use the SSC.  This works around the documented bugs in the SSC when using pascal interfaces.

This allows the print feature to work properly in Apple2TS which emulates an SSC and IWII.